### PR TITLE
WIP: Sync world

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -78,6 +78,16 @@ class World extends EventEmitter {
     if (chunk != null) { this.setColumn(chunkX, chunkZ, chunk, !loaded) }
   }
 
+  async unloadColumn (chunkX, chunkZ, save = true) {
+    const key = columnKeyXZ(chunkX, chunkZ)
+    if (!this.columns[key]) return // already unloaded
+    if (this.anvil && save) {
+      this.queueSaving(chunkX, chunkZ)
+      await this.waitSaving()
+    }
+    delete this.columns[key]
+  }
+
   getColumn (chunkX, chunkZ) {
     const key = columnKeyXZ(chunkX, chunkZ)
     return this.columns[key]

--- a/test/test.js
+++ b/test/test.js
@@ -67,4 +67,12 @@ describe('saving and loading works', function () {
     }
     await world.waitSaving()
   })
+
+  it('initialize', async () => {
+    const world = new World(null, regionPath)
+    await world.initialize((x, y, z) => {
+      return 0
+    }, size * 16, size * 16, 256, new Vec3(0, 0, 0))
+    await world.waitSaving()
+  })
 })


### PR DESCRIPTION
Implements ideas of https://github.com/PrismarineJS/flying-squid/issues/392

* All get / set methods are now sync, get returns `null` or `0` if the column is not loaded, set does nothing if the column is not loaded
* Introduced a `loadColumn` and `loadColumns` methods that are used to load chunks from storage or generate them. Theses methods are async.
* `unloadColumn` to unload chunk (and save it). Async.
* Improved saving by immediately saving when `waitSaving()` is called instead of waiting the next saving tick.
* Added a test for `initialize()`

Tests showed the performances are mostly equivalent between sync/async (`setBlocks` slightly faster for the sync version). Saving immediately improved the tests time.

Integration with mineflayer should be seamless, but flying-squid will require more thinking as it is now the responsibility of the server to make sure columns are loaded before accessing them.

Closes https://github.com/PrismarineJS/prismarine-world/issues/37