### PR TITLE
fix world.sync.getColumns()

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -139,7 +139,7 @@ class World extends EventEmitter {
   }
 
   getColumns () {
-    return Object.values(this.columns).map(([key, column]) => {
+    return Object.entries(this.columns).map(([key, column]) => {
       const parts = key.split(',')
       return {
         chunkX: parts[0],


### PR DESCRIPTION
I tried using mineflayer, which has the sync implementation of pworld and got an Error `Object.items is not a function` and this fixed it