### PR TITLE
Allow for promise to be returned from chunk generator

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -73,7 +73,7 @@ class World extends EventEmitter {
       if (!loaded && this.chunkGenerator) {
         chunk = this.chunkGenerator(chunkX, chunkZ)
       }
-      if (typeof chunk.then == "function") chunk = (await chunk);
+      if (typeof chunk.then === 'function') chunk = (await chunk)
       if (chunk != null) { await this.setColumn(chunkX, chunkZ, chunk, !loaded) }
     }
 

--- a/src/world.js
+++ b/src/world.js
@@ -73,6 +73,7 @@ class World extends EventEmitter {
       if (!loaded && this.chunkGenerator) {
         chunk = this.chunkGenerator(chunkX, chunkZ)
       }
+      if (typeof chunk.then == "function") chunk = (await chunk);
       if (chunk != null) { await this.setColumn(chunkX, chunkZ, chunk, !loaded) }
     }
 

--- a/src/world.js
+++ b/src/world.js
@@ -72,27 +72,27 @@ class World extends EventEmitter {
       }
       const loaded = chunk != null
       if (!loaded && this.chunkGenerator) {
-      	if (this.loadingColumns.includes(key)) {
-      		var abstract = this
-      		return await new Promise((resolve, reject) => {
-      			var iv = setInterval(() => {
-      				if (!abstract.loadingColumns.includes(key)) {
-      					clearInterval(iv)
-      					resolve(abstract.columns[key])
-      				}
-      			}, 1)
-      		})
-      	} else {
-        	chunk = this.chunkGenerator(chunkX, chunkZ)
+        if (this.loadingColumns.includes(key)) {
+          var abstract = this
+          return await new Promise((resolve, reject) => {
+            var iv = setInterval(() => {
+              if (!abstract.loadingColumns.includes(key)) {
+                clearInterval(iv)
+                resolve(abstract.columns[key])
+              }
+            }, 1)
+          })
+        } else {
+          chunk = this.chunkGenerator(chunkX, chunkZ)
         }
       }
       if (typeof chunk.then === 'function') {
-      	this.loadingColumns.push(key)
-      	chunk = (await chunk)
+        this.loadingColumns.push(key)
+        chunk = (await chunk)
       }
       if (chunk != null) { await this.setColumn(chunkX, chunkZ, chunk, !loaded) }
       if (this.loadingColumns.includes(key)) {
-      	this.loadingColumns.splice(this.loadingColumns.indexOf(key), 1)
+        this.loadingColumns.splice(this.loadingColumns.indexOf(key), 1)
       }
     }
 


### PR DESCRIPTION
I'm attempting to make chunk generation threaded in my fork of flying-squid (see [WasabiThumb/flying-squid](https://github.com/WasabiThumb/flying-squid)) but I hit a brick wall when I found out that prismarine-world doesn't accept promises as a result from chunk generators.

This pull request fixes that, and won't break any existing code that returns chunks synchronously. It would be nice for this to be in the main prismarine-world fork instead of an alternative package with a single minute change.