### PR TITLE
update to 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ Set the block `biome` id at `pos`
 
 ## History
 
+### 3.1.1
+
+* fix world.sync.getChunks()
+
 ### 3.1.0
 
 * implement unload column

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismarine-world",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The core implementation of the world for prismarine",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fixes `world.sync.getColumns()`