### PR TITLE
Added match while check intersect

### DIFF
--- a/src/worldsync.js
+++ b/src/worldsync.js
@@ -37,13 +37,14 @@ class WorldSync extends EventEmitter {
     }
   }
 
-  raycast (from, direction, range, matcher = null) {
+  raycast (from, direction, range, matcher = null, intersectMatch = null) {
     const iter = new RaycastIterator(from, direction, range)
     let pos = iter.next()
     while (pos) {
       const position = new Vec3(pos.x, pos.y, pos.z)
       const block = this.getBlock(position)
       if (block && (!matcher || matcher(block))) {
+        if (intersectMatch && intersectMatch(block)) { return block }
         const intersect = iter.intersect(block.shapes, position)
         if (intersect) {
           block.face = intersect.face

--- a/src/worldsync.js
+++ b/src/worldsync.js
@@ -37,19 +37,24 @@ class WorldSync extends EventEmitter {
     }
   }
 
-  raycast (from, direction, range, matcher = null, intersectMatch = null) {
+  raycast (from, direction, range, matcher = null) {
     const iter = new RaycastIterator(from, direction, range)
     let pos = iter.next()
     while (pos) {
       const position = new Vec3(pos.x, pos.y, pos.z)
       const block = this.getBlock(position)
-      if (block && (!matcher || matcher(block))) {
-        if (intersectMatch && intersectMatch(block)) { return block }
-        const intersect = iter.intersect(block.shapes, position)
-        if (intersect) {
-          block.face = intersect.face
-          block.intersect = intersect.pos
-          return block
+      if (block) {
+        if (matcher) {
+          if (matcher(block, iter)) {
+            return block
+          }
+        } else {
+          const intersect = iter.intersect(block.shapes, position)
+          if (intersect) {
+            block.face = intersect.face
+            block.intersect = intersect.pos
+            return block
+          }
         }
       }
       pos = iter.next()


### PR DESCRIPTION
Hi guys i'm interesed to check intersect at same time with other conditions,

Currently if i use match they no checks the intersect

```js
  if (block && (!matcher || matcher(block))) { // <<---
        const intersect = iter.intersect(block.shapes, position)
        if (intersect) {
          block.face = intersect.face
          block.intersect = intersect.pos
          return block
        }
      }
```

With this a small change can we use both,

** With this change I make a PR to block.js -> "canSeeBlock"
```js
function canSeeBlock (block, range = 5) {
    const headPos = bot.entity.position.offset(0, bot.entity.height, 0)
    const dir = block.position.offset(0.5, 0.5, 0.5).minus(headPos)
    const intersectMatch = inputBlock => block.position.equals(inputBlock.position) // <<--- also check position for avoid problems of water / air positions
    const blockAtCursor = bot.world.raycast(headPos, dir.normalize(), range, null, intersectMatch)
    return blockAtCursor && blockAtCursor.position.equals(block.position)
  }
```


