### PR TITLE
Floor ManhattanIterator maxDistance

### DIFF
--- a/src/iterators.js
+++ b/src/iterators.js
@@ -5,7 +5,7 @@ const { Vec3 } = require('vec3')
 // https://en.wikipedia.org/wiki/Taxicab_geometry
 class ManhattanIterator {
   constructor (x, y, maxDistance) {
-    this.maxDistance = maxDistance
+    this.maxDistance = Math.floor(maxDistance)
     this.startx = x
     this.starty = y
     this.x = 2


### PR DESCRIPTION
Because an `===` check is done on the distance, using a non-integer will cause the loop to hang