### PR TITLE
Fix https://github.com/PrismarineJS/prismarine-provider-anvil/issues/63

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -124,7 +124,7 @@ class World extends EventEmitter {
 
   unloadColumn (chunkX, chunkZ) {
     const key = columnKeyXZ(chunkX, chunkZ)
-    if (this.savingQueue.has(key)) {
+    if (this.storageProvider && this.savingQueue.has(key)) {
       this.unloadQueue.set(key, { chunkX, chunkZ })
     } else {
       delete this.columns[key]

--- a/src/world.js
+++ b/src/world.js
@@ -158,10 +158,9 @@ class World extends EventEmitter {
     if (this.savingInterval !== 0) {
       this.savingInt = setTimeout(async () => {
         this.saveNow()
-          .then( () => {
+          .then(() => {
             this.startSaving()
-          }
-        )
+          })
       }, this.savingInterval)
     }
   }

--- a/src/world.js
+++ b/src/world.js
@@ -92,7 +92,7 @@ class World extends EventEmitter {
       }
       const loaded = chunk != null
       if (!loaded && this.chunkGenerator) {
-        chunk = await this.chunkGenerator(chunkX, chunkZ)
+        chunk = this.chunkGenerator(chunkX, chunkZ)
       }
       if (chunk != null) { await this.setColumn(chunkX, chunkZ, chunk, !loaded) }
     }

--- a/src/world.js
+++ b/src/world.js
@@ -125,7 +125,7 @@ class World extends EventEmitter {
   unloadColumn (chunkX, chunkZ) {
     const key = columnKeyXZ(chunkX, chunkZ)
     if (this.savingQueue.has(key)) {
-      this.unloadQueue.set(key, { chunkX, chunkZ })      
+      this.unloadQueue.set(key, { chunkX, chunkZ })
     } else {
       delete this.columns[key]
       const columnCorner = new Vec3(chunkX * 16, 0, chunkZ * 16)
@@ -142,12 +142,12 @@ class World extends EventEmitter {
     for (const [key, { chunkX, chunkZ }] of this.savingQueue.entries()) {
       this.finishedSaving = Promise.all([this.finishedSaving,
         this.storageProvider.save(chunkX, chunkZ, this.columns[key])
-         .then(() => {
+          .then(() => {
             if (this.unloadQueue.has(key)) {
               this.unloadQueue.delete(key)
               this.unloadColumn(chunkX, chunkZ)
-          }
-        })
+            }
+          })
       ])
     }
     this.savingQueue.clear()

--- a/src/world.js
+++ b/src/world.js
@@ -18,6 +18,7 @@ class World extends EventEmitter {
     this.savingQueue = new Map()
     this.unloadQueue = new Map()
     this.finishedSaving = Promise.resolve()
+    this.currentlySaving = false // semaphore for saving
     this.columns = {}
     this.chunkGenerator = chunkGenerator
     this.storageProvider = storageProvider
@@ -143,7 +144,6 @@ class World extends EventEmitter {
       this.finishedSaving = Promise.all([this.finishedSaving,
         this.storageProvider.save(chunkX, chunkZ, this.columns[key])
           .then(() => {
-            this.savingQueue.delete(key)
             if (this.unloadQueue.has(key)) {
               this.unloadQueue.delete(key)
               this.unloadColumn(chunkX, chunkZ)
@@ -151,18 +151,18 @@ class World extends EventEmitter {
           })
       ])
     }
+    this.savingQueue.clear()
     this.emit('doneSaving')
   }
 
   startSaving () {
-    if (this.savingInterval !== 0) {
-      this.savingInt = setTimeout(async () => {
-        this.saveNow()
-          .then(() => {
-            this.startSaving()
-          })
-      }, this.savingInterval)
-    }
+    this.savingInt = setInterval(async () => {
+      if (this.currentlySaving === false) {
+        this.currentlySaving = true
+        await this.saveNow()
+        this.currentlySaving = false
+      }
+    }, this.savingInterval)
   }
 
   async waitSaving () {
@@ -174,7 +174,7 @@ class World extends EventEmitter {
   }
 
   stopSaving () {
-    this.savingInterval = 0
+    clearInterval(this.savingInt)
   }
 
   queueSaving (chunkX, chunkZ) {


### PR DESCRIPTION
Fixes:
https://github.com/PrismarineJS/prismarine-provider-anvil/issues/63
https://github.com/PrismarineJS/flying-squid/issues/584
https://github.com/PrismarineJS/flying-squid/issues/566

prismarine-world was unloading columns before the chunk saving queue was handling some of them, especially when the chunk saving queue was large, resulting in null chunks being written to file. On returning to the same location, prismarine-world was loading the null chunk and crashing.

Resolved by adding an unloadQueue for chunks on in the savingQueue and postponing unloading columns until written.