### PR TITLE
Fix ManhattanIterator

### DIFF
--- a/src/iterators.js
+++ b/src/iterators.js
@@ -24,11 +24,15 @@ class ManhattanIterator {
     this.leg = -1
   }
 
+  /**
+   * Returns the next position. If the iterator is at the end, returns null. Position will be 2d along the x z plane and y always being 0.
+   * @returns {Vec3 | null} 
+   */
   next () {
     if (this.leg === -1) {
       // use -1 as the center
       this.leg = 0
-      return { x: this.startx, y: this.starty }
+      return new Vec3(this.startx, 0, this.starty)
     } else if (this.leg === 0) {
       if (this.maxDistance === 1) return null
       this.x--

--- a/src/iterators.js
+++ b/src/iterators.js
@@ -26,7 +26,7 @@ class ManhattanIterator {
 
   /**
    * Returns the next position. If the iterator is at the end, returns null. Position will be 2d along the x z plane and y always being 0.
-   * @returns {Vec3 | null} 
+   * @returns {Vec3 | null}
    */
   next () {
     if (this.leg === -1) {

--- a/test/iterator.test.js
+++ b/test/iterator.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-const { SpiralIterator2d } = require('../src/iterators')
+const { SpiralIterator2d, ManhattanIterator } = require('../src/iterators')
 const { Vec3 } = require('vec3')
 const expect = require('expect').default
 
@@ -13,5 +13,27 @@ describe('Spiral iterator', () => {
 
     expect(first.x === startPos.x && first.y === startPos.y && first.z === startPos.z).toBeTruthy()
     expect(second.x === startPos.x && second.y === startPos.y && second.z === startPos.z).toBeFalsy()
+  })
+})
+
+describe('ManhattanIterator iterator', () => {
+  it('First position is same as start', () => {
+    const start = new Vec3(1, 2, 3)
+    const iter = new ManhattanIterator(start.x, start.z, 5)
+    const first = iter.next()
+    expect(first.x === start.x && first.z === start.z).toBeTruthy()
+  })
+
+  it('Sample positions match', () => {
+    const start = new Vec3(1, 2, 3)
+    const iter = new ManhattanIterator(start.x, start.z, 5)
+    const sample = [new Vec3(1, 0, 3), new Vec3(2, 0, 3), new Vec3(1, 0, 4), new Vec3(0, 0, 3)]
+    let counter = 0
+    let next = iter.next()
+    while (next && counter < sample.length) {
+      expect(next.x === sample[counter].x && next.z === sample[counter].z).toBeTruthy()
+      next = iter.next()
+      counter++
+    }
   })
 })


### PR DESCRIPTION
The current implementation has a bug where the first position return will be wrong. It currently switches y and z resulting in z being undefined when it should by the y value.