### PR TITLE
Add new cached block loops and builder

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -46,6 +46,9 @@ Note that `oldBlock` may be `null`.
 Fires when a chunk has updated. `point` is the coordinates to the corner
 of the chunk with the smallest x, y, and z values.
 
+### World.setRegistry (registry)
+Sets the prismarine-registry instance to use for block data
+
 ### World.initialize(iniFunc,length,width,height=256,iniPos=new Vec3(0,0,0))
 
 Initialize the world with a given blocks cube. Useful to load quickly a schematic.
@@ -143,11 +146,25 @@ Set the block `biome` id at `pos`
 
 Returns a promise that is resolved when all saving is done.
 
+### World.saveAndQuit([timeout])
+
+Save all chunks and stop all timers. Returns a promise that is resolved when all saving is done.
+
 ### World.sync(asyncWorld)
 
 Build a sync world, will delegate all the saving work to the async one
 
-It exposes the same methods as World but all methods are sync.
+It exposes the same methods as World except `getCachedBlock()` but all methods are sync.
+
+### .buildBlockCache()
+
+Builds block cache that enables usage of the getCachedBlock() method. Requires that .setRegistry() has been called with a prismarine-registry instance.
+
+### .getCachedBlock(pos)
+
+Returns a prismarine-block instance of the block at the given position. If the block is not in the cache, it will be loaded from the world.
+The purpose of this function is to prevent the construction of a new prismarine-block instance, which can be helpful in hot code to lessen
+the creation of temporary object garbage.
 
 ## Iterators
 

--- a/package.json
+++ b/package.json
@@ -32,19 +32,17 @@
   },
   "homepage": "https://github.com/PrismarineJS/prismarine-world",
   "devDependencies": {
-    "buffer-equal": "^1.0.0",
     "expect": "^29.1.0",
     "flatmap": "0.0.3",
-    "minecraft-data": "^3.0.0",
+    "minecraft-data": "^3.59.3",
     "mkdirp": "^0.5.1",
     "mocha": "^10.0.0",
     "prismarine-chunk": "^1.31.0",
     "prismarine-provider-anvil": "^2.0.0",
     "prismarine-provider-raw": "^1.0.1",
+    "prismarine-registry": "^1.7.0",
     "prismarine-world": "file:.",
-    "process": "^0.11.0",
     "range": "0.0.3",
-    "rimraf": "^3.0.2",
     "standard": "^17.0.0"
   },
   "dependencies": {

--- a/src/worldsync.js
+++ b/src/worldsync.js
@@ -94,6 +94,21 @@ class WorldSync extends EventEmitter {
   }
 
   // Block accessors:
+  buildBlockCache () {
+    if (!this.async.Block) throw new Error('Registry not set')
+    const blockStates = this.async.registry.blocksByStateId
+    this.blockCache = {}
+    for (const stateId in blockStates) {
+      this.blockCache[stateId] = this.async.Block.fromStateId(stateId)
+    }
+  }
+
+  getCachedBlock (pos) {
+    const chunk = this.getColumnAt(pos)
+    if (!chunk) return null
+    const block = this.blockCache[chunk.getBlockStateId(posInChunk(pos))]
+    return block
+  }
 
   getBlock (pos) {
     const chunk = this.getColumnAt(pos)

--- a/test/test.js
+++ b/test/test.js
@@ -1,39 +1,38 @@
 /* eslint-env mocha */
 
+const fs = require('fs')
 const flatMap = require('flatmap')
 const range = require('range').range
-const bufferEqual = require('buffer-equal')
 const World = require('../')('1.8')
 const Chunk = require('prismarine-chunk')('1.8')
 const Vec3 = require('vec3').Vec3
 const assert = require('assert')
 const mkdirp = require('mkdirp')
-const rimraf = require('rimraf')
 const Anvil = require('prismarine-provider-anvil').Anvil('1.8')
+const registry = require('prismarine-registry')('1.8')
 
-describe('saving and loading works', function () {
-  function generateRandomChunk (chunkX, chunkZ) {
-    const chunk = new Chunk()
-
-    for (let x = 0; x < 16; x++) {
-      for (let z = 0; z < 16; z++) {
-        chunk.setBlockType(new Vec3(x, 50, z), Math.floor(Math.random() * 50))
-        for (let y = 0; y < 256; y++) {
-          chunk.setSkyLight(new Vec3(x, y, z), 15)
-        }
+function generateRandomChunk (chunkX, chunkZ) {
+  const chunk = new Chunk()
+  for (let x = 0; x < 16; x++) {
+    for (let z = 0; z < 16; z++) {
+      chunk.setBlockType(new Vec3(x, 50, z), Math.floor(Math.random() * 50))
+      for (let y = 0; y < 256; y++) {
+        chunk.setSkyLight(new Vec3(x, y, z), 15)
       }
     }
-
-    return chunk
   }
+  return chunk
+}
 
+describe('saving and loading works', function () {
   const regionPath = 'world/testRegion'
   before((cb) => {
     mkdirp(regionPath, cb)
   })
 
   after(cb => {
-    rimraf(regionPath, cb)
+    try { fs.rmSync(regionPath, { recursive: true, force: true }) } catch {}
+    cb()
   })
 
   let originalWorld
@@ -45,7 +44,7 @@ describe('saving and loading works', function () {
       flatMap(range(0, size), (chunkX) => range(0, size).map(chunkZ => ({ chunkX, chunkZ })))
         .map(({ chunkX, chunkZ }) => originalWorld.getColumn(chunkX, chunkZ))
     )
-    await originalWorld.waitSaving()
+    await originalWorld.saveAndQuit()
   })
 
   it('load the world correctly', async () => {
@@ -56,9 +55,10 @@ describe('saving and loading works', function () {
           const originalChunk = await originalWorld.getColumn(chunkX, chunkZ)
           const loadedChunk = await loadedWorld.getColumn(chunkX, chunkZ)
           assert.strictEqual(originalChunk.getBlockType(new Vec3(0, 50, 0)), loadedChunk.getBlockType(new Vec3(0, 50, 0)), 'wrong block type at 0,50,0 of chunk ' + chunkX + ',' + chunkZ)
-          assert(bufferEqual(originalChunk.dump(), loadedChunk.dump()))
+          assert(originalChunk.dump().equals(loadedChunk.dump()))
         })
     )
+    await loadedWorld.saveAndQuit()
   })
 
   it('setBlocks', async () => {
@@ -66,33 +66,19 @@ describe('saving and loading works', function () {
     for (let i = 0; i < 10000; i++) {
       await world.setBlockType(new Vec3(Math.random() * (16 * size - 1), Math.random() * 255, Math.random() * (16 * size - 1)), 0)
     }
-    await world.waitSaving()
+    await world.saveAndQuit()
   })
 })
 
 describe('Synchronous saving and loading works', function () {
-  function generateRandomChunk (chunkX, chunkZ) {
-    const chunk = new Chunk()
-
-    for (let x = 0; x < 16; x++) {
-      for (let z = 0; z < 16; z++) {
-        chunk.setBlockType(new Vec3(x, 50, z), Math.floor(Math.random() * 50))
-        for (let y = 0; y < 256; y++) {
-          chunk.setSkyLight(new Vec3(x, y, z), 15)
-        }
-      }
-    }
-
-    return chunk
-  }
-
   const regionPath = 'world/testRegionSync'
   before((cb) => {
     mkdirp(regionPath, cb)
   })
 
   after(cb => {
-    rimraf(regionPath, cb)
+    try { fs.rmSync(regionPath, { recursive: true, force: true }) } catch {}
+    cb()
   })
 
   let originalWorld
@@ -104,7 +90,7 @@ describe('Synchronous saving and loading works', function () {
       flatMap(range(0, size), (chunkX) => range(0, size).map(chunkZ => ({ chunkX, chunkZ })))
         .map(({ chunkX, chunkZ }) => originalWorld.getColumn(chunkX, chunkZ))
     )
-    await originalWorld.waitSaving()
+    await originalWorld.saveAndQuit()
   })
 
   it('load the world correctly', async () => {
@@ -116,9 +102,10 @@ describe('Synchronous saving and loading works', function () {
           const originalChunk = originalWorld.sync.getColumn(chunkX, chunkZ)
           const loadedChunk = loadedWorld.sync.getColumn(chunkX, chunkZ)
           assert.strictEqual(originalChunk.getBlockType(new Vec3(0, 50, 0)), loadedChunk.getBlockType(new Vec3(0, 50, 0)), 'wrong block type at 0,50,0 of chunk ' + chunkX + ',' + chunkZ)
-          assert(bufferEqual(originalChunk.dump(), loadedChunk.dump()))
+          assert(originalChunk.dump().equals(loadedChunk.dump()))
         })
     )
+    await loadedWorld.saveAndQuit()
   })
 
   it('setBlocks', async () => {
@@ -126,6 +113,20 @@ describe('Synchronous saving and loading works', function () {
     for (let i = 0; i < 10000; i++) {
       world.sync.setBlockType(new Vec3(Math.random() * (16 * size - 1), Math.random() * 255, Math.random() * (16 * size - 1)), 0)
     }
-    await world.waitSaving()
+    await world.saveAndQuit()
+  })
+
+  it('cached blocks work', async () => {
+    const world = new World(generateRandomChunk)
+    world.setRegistry(registry)
+    world.sync.buildBlockCache()
+
+    const pos = new Vec3(0, 60, 0)
+    const blockStateId = 66
+    await world.setBlockStateId(pos, blockStateId)
+    const block = world.sync.getCachedBlock(pos)
+    console.log('Block is', block)
+    assert(block.stateId == blockStateId) // eslint-disable-line eqeqeq
+    await world.saveAndQuit()
   })
 })

--- a/types/world.d.ts
+++ b/types/world.d.ts
@@ -44,6 +44,8 @@ export declare class World extends EventEmitter {
         iniPos?: Vec3,
     ): Promise<ChunkCoordinates[]>;
 
+    setRegistry (registry): void;
+
     /**
      * 
      * @param {Vec3} from Position to start raycasting from.
@@ -91,6 +93,8 @@ export declare class World extends EventEmitter {
     public waitSaving(): Promise<void>;
 
     public stopSaving(): void;
+
+    public saveAndQuit(timeout?): Promise<void>;
 
     public queueSaving(chunkX: number, chunkZ: number): void;
 
@@ -184,6 +188,9 @@ export declare class WorldSync extends EventEmitter {
     ): void;
 
     public unloadColumn(chunkX: number, chunkZ: number): void;
+
+    public buildBlockCache(): void;
+    public getCachedBlock(pos: Vec3): Block;
 
     public getBlock(pos: Vec3): Block;
 


### PR DESCRIPTION
Adds cached block lookup API like done [in prismarine-viewer](https://github.com/PrismarineJS/prismarine-viewer/blob/cd324fe1ed7840eef677100d322d06e3dc08e859/viewer/lib/world.js#L66) for performance (to avoid object creation).

Adds a `.getCachedBlock(pos)` replacement for `.getBlock(pos)`, and a `.buildBlockCache()` function that has to be called to build the block cache (ideally after prismarine-world instantiation).

Also add a saveAndQuit() method to save and close timers to not hang tests.