### PR TITLE
Add missing RaycastResult Import

### DIFF
--- a/types/world.d.ts
+++ b/types/world.d.ts
@@ -2,7 +2,7 @@ import type { EventEmitter } from "events";
 import type { Vec3 } from "vec3";
 import type { Block } from "prismarine-block";
 import loaderOfChunk from "prismarine-chunk";
-import type { RaycastBlock } from "./iterators";
+import type { RaycastBlock, RaycastResult } from "./iterators";
 
 export type Chunk = InstanceType<ReturnType<typeof loaderOfChunk>>;
 

--- a/types/world.d.ts
+++ b/types/world.d.ts
@@ -56,7 +56,7 @@ export declare class World extends EventEmitter {
         direction: Vec3,
         range: number,
         matcher?: (block: Block) => boolean,
-    ): Promise<RaycastBlock | null>;
+    ): Promise<RaycastResult | null>;
 
     public getLoadedColumn(chunkX: number, chunkZ: number): Chunk;
 

--- a/types/world.d.ts
+++ b/types/world.d.ts
@@ -2,7 +2,7 @@ import type { EventEmitter } from "events";
 import type { Vec3 } from "vec3";
 import type { Block } from "prismarine-block";
 import loaderOfChunk from "prismarine-chunk";
-import type { RaycastBlock, RaycastResult } from "./iterators";
+import type { RaycastResult } from "./iterators";
 
 export type Chunk = InstanceType<ReturnType<typeof loaderOfChunk>>;
 


### PR DESCRIPTION
Additionally changes the return type of `World`'s `raycast` from `Promise<RaycastBlock | null>` to `Promise<RaycastResult | null>`, because it seems to additionally have the `intersect` prop (https://github.com/PrismarineJS/prismarine-world/blob/master/src/world.js#L70)