### PR TITLE
fix: The raycast was skipping the block that the client is inside.

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -59,7 +59,7 @@ class World extends EventEmitter {
 
   async raycast (from, direction, range, matcher = null) {
     const iter = new RaycastIterator(from, direction, range)
-    let pos = iter.next()
+    let pos = from
     while (pos) {
       const position = new Vec3(pos.x, pos.y, pos.z)
       const block = await this.getBlock(position)

--- a/src/worldsync.js
+++ b/src/worldsync.js
@@ -39,7 +39,7 @@ class WorldSync extends EventEmitter {
 
   raycast (from, direction, range, matcher = null) {
     const iter = new RaycastIterator(from, direction, range)
-    let pos = iter.next()
+    let pos = from
     while (pos) {
       const position = new Vec3(pos.x, pos.y, pos.z)
       const block = this.getBlock(position)

--- a/test/raycast.test.js
+++ b/test/raycast.test.js
@@ -46,4 +46,12 @@ describe('raycasting', function () {
     const down = await world.raycast(head, new Vec3(0, -1, 0), 10)
     assert.notStrictEqual(down, null)
   })
+
+  it('raycast inside a block', async () => {
+    const head = new Vec3(0, 3.6, 0)
+    const inside = await world.raycast(head, new Vec3(0, 0, 1), 10)
+    assert.strictEqual(inside.position.x, 0)
+    assert.strictEqual(inside.position.y, 3)
+    assert.strictEqual(inside.position.z, 0)
+  })
 })


### PR DESCRIPTION
That was causing major client misalignment. I don't see a reason why it should be otherwise. There are so many valid cases like being inside the door or bushes.