### PR TITLE
Add basic entity storage to prismarine-world

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -20,6 +20,7 @@ class World extends EventEmitter {
     this.finishedSaving = Promise.resolve()
     this.currentlySaving = false // semaphore for saving
     this.columns = {}
+    this.entities = new Map() // Entity storage by UUID
     this.chunkGenerator = chunkGenerator
     this.storageProvider = storageProvider
     this.savingInterval = savingInterval
@@ -306,6 +307,23 @@ class World extends EventEmitter {
     chunk.setBiome(pInChunk, biome)
     this.saveAt(pos)
     this._emitBlockUpdate(oldBlock, chunk.getBlock(pInChunk), pos)
+  }
+
+  // Basic entity storage methods
+  setEntity (uuid, entityData) {
+    this.entities.set(uuid, entityData)
+  }
+
+  getEntity (uuid) {
+    return this.entities.get(uuid)
+  }
+
+  removeEntity (uuid) {
+    return this.entities.delete(uuid)
+  }
+
+  getAllEntities () {
+    return Array.from(this.entities.values())
   }
 }
 

--- a/src/worldsync.js
+++ b/src/worldsync.js
@@ -208,6 +208,23 @@ class WorldSync extends EventEmitter {
     this.async.saveAt(pos)
     this._emitBlockUpdate(oldBlock, chunk.getBlock(pInChunk), pos)
   }
+
+  // Sync entity storage methods
+  setEntity (uuid, entityData) {
+    this.async.setEntity(uuid, entityData)
+  }
+
+  getEntity (uuid) {
+    return this.async.getEntity(uuid)
+  }
+
+  removeEntity (uuid) {
+    return this.async.removeEntity(uuid)
+  }
+
+  getAllEntities () {
+    return this.async.getAllEntities()
+  }
 }
 
 module.exports = WorldSync


### PR DESCRIPTION
## Summary
Add basic entity storage infrastructure to prismarine-world as first step toward consolidating all world state.

## Changes
- Add `entities` Map to World class for storing entities by UUID
- Add `setEntity()`, `getEntity()`, `removeEntity()`, `getAllEntities()` methods
- Add corresponding sync methods to WorldSync class
- All existing tests pass

## Context
This is the minimal first step for issue PrismarineJS/mineflayer#334 - moving all world state (blocks, entities, inventories) into prismarine-world for better packaging and modularity.

Next steps will be to move block inventories and eventually player inventories to use this storage.

## Testing
- [x] All existing tests pass
- [x] No breaking changes to existing API

🤖 Generated with [Claude Code](https://claude.ai/code)